### PR TITLE
Resolves #57: CI improvements

### DIFF
--- a/Scripts/check-for-changes.sh
+++ b/Scripts/check-for-changes.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Check if there were any changes in the Source directory
+! git diff `echo "$CIRCLE_COMPARE_URL" | cut -d '/' -f 7` --name-only --exit-code Source Scripts circle.yml

--- a/Scripts/check-for-source-update.sh
+++ b/Scripts/check-for-source-update.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 # Check if there were any changes in the Source directory
-! git diff `echo $CIRCLE_COMPARE_URL | cut -d ' ' -f 7` --name-only --exit-code Source
+! git diff `echo "$CIRCLE_COMPARE_URL" | cut -d '/' -f 7` --name-only --exit-code Source

--- a/Scripts/check-for-source-update.sh
+++ b/Scripts/check-for-source-update.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-# Check if there were any changes in the Source directory
-! git diff `echo "$CIRCLE_COMPARE_URL" | cut -d '/' -f 7` --name-only --exit-code Source

--- a/Scripts/check-for-source-update.sh
+++ b/Scripts/check-for-source-update.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+# Check if there were any changes in the Source directory
+! git diff `echo $CIRCLE_COMPARE_URL | cut -d ' ' -f 7` --name-only --exit-code Source

--- a/Scripts/prepare_release.sh
+++ b/Scripts/prepare_release.sh
@@ -7,8 +7,6 @@ cp Source/Readme+License.html /tmp
 
 # Switch to release branch
 git checkout release
-# Reset to base
-git reset --hard 3706c287808e9916b00f68202a658791e6876e94
 
 cd _release
 for f in Monoid-Regular*.ttf; do

--- a/Source/Readme+License.html
+++ b/Source/Readme+License.html
@@ -1,6 +1,5 @@
 <!DOCTYPE html>
 <html>
-
 <head>
   <meta http-equiv="refresh" content="0; url=https://github.com/larsenwork/monoid#readme">
 </head>
@@ -8,5 +7,4 @@
 <body>
   <p>You can find the readme on <a href="https://github.com/larsenwork/monoid#readme">this page</a></p>
 </body>
-
 </html>

--- a/circle.yml
+++ b/circle.yml
@@ -12,8 +12,8 @@ checkout:
     - git remote set-url origin "git@github.com:${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
     - git fetch -f origin release-template:release
     - git fetch -f origin gh-pages:gh-pages
-    # Check for a source update, otherwise fail the build
-    - . Scripts/check-for-source-update.sh
+    # Check for any changes,  otherwise fail the build
+    - . Scripts/check-for-changes.sh
     - git config --global user.email "chase+circleci@colman.io"
     - git config --global user.name "CircleCI Bot"
 dependencies:

--- a/circle.yml
+++ b/circle.yml
@@ -1,17 +1,19 @@
 general:
   branches:
-    only:
-      - master
+    ignore:
+      - release
+      - gh-pages
+      - release-template
 machine:
   services:
     - docker
 checkout:
   post:
     - git remote set-url origin "git@github.com:${CIRCLE_PROJECT_USERNAME}/${CIRCLE_PROJECT_REPONAME}.git"
-    - git fetch -f origin release:release
+    - git fetch -f origin release-template:release
     - git fetch -f origin gh-pages:gh-pages
-    # Check if there were any changes in the Source directory since the last release
-    #- "! git diff `git log -1 --pretty='%B' release | cut -d ' ' -f 4` --name-only --exit-code Source"
+    # Check for a source update, otherwise fail the build
+    - . Scripts/check-for-source-update.sh
     - git config --global user.email "chase+circleci@colman.io"
     - git config --global user.name "CircleCI Bot"
 dependencies:


### PR DESCRIPTION
Now it fails on `- . Scripts/check-for-changes.sh` if there are no changes.
Also uses the `release-template` branch for `release`. That way we can change the base release without having to pull the ~.5GB `release` branch. Also makes pushes faster because it doesn't rewrite local history and prevents the source cache from being polluted.