### PR TITLE
Readme - Which terminals don't support calt on Linux

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -51,9 +51,9 @@ I'm using opentype features `calt` + `liga` to create the ligatures and add cont
 
 | Working | Not Working |
 |---|---|
-| Atom - All platforms | Gnome Terminal - Linux |
+| Atom - All platforms | libvte based terminals - Linux |
 | Eclipse - All platforms | gVim - Linux |
-| gEdit - Linux ||
+| gEdit - Linux | Xterm, Urxvt -Linux |
 | Xcode - Mac ||
 
 ###Browsers


### PR DESCRIPTION
I have made some brief changes to the Readme in order to be clear about which terminals on Linux do not support calt.